### PR TITLE
Fix indentation; Better naming of MapSinglePanel() parameters.

### DIFF
--- a/lib/multiplex-mappers.cc
+++ b/lib/multiplex-mappers.cc
@@ -21,58 +21,58 @@ namespace internal {
 // mapping in a panel or panel-assembly, which depends on the wiring.
 class MultiplexMapperBase : public MultiplexMapper {
 public:
-    MultiplexMapperBase(const char *name, int stretch_factor)
-        : name_(name), panel_stretch_factor_(stretch_factor) {}
+  MultiplexMapperBase(const char *name, int stretch_factor)
+    : name_(name), panel_stretch_factor_(stretch_factor) {}
 
-    // This method is const, but we sneakily remember the original size
-    // of the panels so that we can more easily quantize things.
-    // So technically, we're stateful, but let's pretend we're not changing
-    // state. In the context this is used, it is never accessed in multiple
-    // threads.
-    virtual void EditColsRows(int *cols, int *rows) const {
-        panel_rows_ = *rows;
-        panel_cols_ = *cols;
+  // This method is const, but we sneakily remember the original size
+  // of the panels so that we can more easily quantize things.
+  // So technically, we're stateful, but let's pretend we're not changing
+  // state. In the context this is used, it is never accessed in multiple
+  // threads.
+  virtual void EditColsRows(int *cols, int *rows) const {
+    panel_rows_ = *rows;
+    panel_cols_ = *cols;
 
-        *rows /= panel_stretch_factor_;
-        *cols *= panel_stretch_factor_;
-    }
+    *rows /= panel_stretch_factor_;
+    *cols *= panel_stretch_factor_;
+  }
 
-    virtual bool GetSizeMapping(int matrix_width, int matrix_height,
-                                int *visible_width, int *visible_height) const {
-        // Matrix width has been altered. Alter it back.
-        *visible_width = matrix_width / panel_stretch_factor_;
-        *visible_height = matrix_height * panel_stretch_factor_;
-        return true;
-    }
+  virtual bool GetSizeMapping(int matrix_width, int matrix_height,
+                              int *visible_width, int *visible_height) const {
+    // Matrix width has been altered. Alter it back.
+    *visible_width = matrix_width / panel_stretch_factor_;
+    *visible_height = matrix_height * panel_stretch_factor_;
+    return true;
+  }
 
-    virtual const char *GetName() const { return name_; }
+  virtual const char *GetName() const { return name_; }
 
-    // The MapVisibleToMatrix() as required by PanelMatrix here does
-    virtual void MapVisibleToMatrix(int matrix_width, int matrix_height,
-                                    int visible_x, int visible_y,
-                                    int *matrix_x, int *matrix_y) const {
-        const int chained_panel  = visible_x / panel_cols_;
-        const int parallel_panel = visible_y / panel_rows_;
+  // The MapVisibleToMatrix() as required by PanelMatrix here does
+  virtual void MapVisibleToMatrix(int matrix_width, int matrix_height,
+                                  int visible_x, int visible_y,
+                                  int *matrix_x, int *matrix_y) const {
+    const int chained_panel  = visible_x / panel_cols_;
+    const int parallel_panel = visible_y / panel_rows_;
 
-        const int within_panel_x = visible_x % panel_cols_;
-        const int within_panel_y = visible_y % panel_rows_;
+    const int within_panel_x = visible_x % panel_cols_;
+    const int within_panel_y = visible_y % panel_rows_;
 
-        int new_x, new_y;
-        MapSinglePanel(within_panel_x, within_panel_y, &new_x, &new_y);
-        *matrix_x = chained_panel  * panel_stretch_factor_*panel_cols_ + new_x;
-        *matrix_y = parallel_panel * panel_rows_/panel_stretch_factor_ + new_y;
-    }
+    int new_x, new_y;
+    MapSinglePanel(within_panel_x, within_panel_y, &new_x, &new_y);
+    *matrix_x = chained_panel  * panel_stretch_factor_*panel_cols_ + new_x;
+    *matrix_y = parallel_panel * panel_rows_/panel_stretch_factor_ + new_y;
+  }
 
-    // Map the coordinates for a single panel. This is to be overridden in
-    // derived classes.
-    virtual void MapSinglePanel(int phys_x, int phys_y,
-                                int *logic_x, int *logic_y) const = 0;
+  // Map the coordinates for a single panel. This is to be overridden in
+  // derived classes.
+  virtual void MapSinglePanel(int visible_x, int visible_y,
+                              int *matrix_x, int *matrix_y) const = 0;
 protected:
-    const char *const name_;
-    const int panel_stretch_factor_;
+  const char *const name_;
+  const int panel_stretch_factor_;
 
-    mutable int panel_cols_;
-    mutable int panel_rows_;
+  mutable int panel_cols_;
+  mutable int panel_rows_;
 };
 
 
@@ -89,62 +89,62 @@ protected:
  */
 class StripeMultiplexMapper : public MultiplexMapperBase {
 public:
-    StripeMultiplexMapper() : MultiplexMapperBase("Stripe", 2) {}
+  StripeMultiplexMapper() : MultiplexMapperBase("Stripe", 2) {}
 
-    void MapSinglePanel(int x, int y, int *logic_x, int *logic_y) const {
-        const bool is_top_stripe = (y % (panel_rows_/2)) < panel_rows_/4;
-        *logic_x = is_top_stripe ? x + panel_cols_ : x;
-        *logic_y = ((y / (panel_rows_/2)) * (panel_rows_/4)
-                    + y % (panel_rows_/4));
-    }
+  void MapSinglePanel(int x, int y, int *matrix_x, int *matrix_y) const {
+    const bool is_top_stripe = (y % (panel_rows_/2)) < panel_rows_/4;
+    *matrix_x = is_top_stripe ? x + panel_cols_ : x;
+    *matrix_y = ((y / (panel_rows_/2)) * (panel_rows_/4)
+                 + y % (panel_rows_/4));
+  }
 };
 
 class CheckeredMultiplexMapper : public MultiplexMapperBase {
 public:
-    CheckeredMultiplexMapper() : MultiplexMapperBase("Checkered", 2) {}
+  CheckeredMultiplexMapper() : MultiplexMapperBase("Checkered", 2) {}
 
-    void MapSinglePanel(int x, int y, int *logic_x, int *logic_y) const {
-        const bool is_top_check = (y % (panel_rows_/2)) < panel_rows_/4;
-        const bool is_left_check = (x < panel_cols_/2);\
-        if (is_top_check) {
-            *logic_x = is_left_check ? x+panel_cols_/2 : x+panel_cols_;
-        } else {
-            *logic_x = is_left_check ? x : x + panel_cols_/2;
-        }
-        *logic_y = ((y / (panel_rows_/2)) * (panel_rows_/4)
-                    + y % (panel_rows_/4));
+  void MapSinglePanel(int x, int y, int *matrix_x, int *matrix_y) const {
+    const bool is_top_check = (y % (panel_rows_/2)) < panel_rows_/4;
+    const bool is_left_check = (x < panel_cols_/2);
+    if (is_top_check) {
+      *matrix_x = is_left_check ? x+panel_cols_/2 : x+panel_cols_;
+    } else {
+      *matrix_x = is_left_check ? x : x + panel_cols_/2;
     }
+    *matrix_y = ((y / (panel_rows_/2)) * (panel_rows_/4)
+                 + y % (panel_rows_/4));
+  }
 };
 
 class SpiralMultiplexMapper : public MultiplexMapperBase {
 public:
-    SpiralMultiplexMapper() : MultiplexMapperBase("Spiral", 2) {}
+  SpiralMultiplexMapper() : MultiplexMapperBase("Spiral", 2) {}
 
-    void MapSinglePanel(int x, int y, int *logic_x, int *logic_y) const {
-        const bool is_top_stripe = (y % (panel_rows_/2)) < panel_rows_/4;
-        const int panel_quarter = panel_cols_/4;
-        const int quarter = x / panel_quarter;
-        const int offset = x % panel_quarter;
-        *logic_x = ((2*quarter*panel_quarter)
-                    + (is_top_stripe
-                       ? panel_quarter - 1 - offset
-                       : panel_quarter + offset));
-        *logic_y = ((y / (panel_rows_/2)) * (panel_rows_/4)
-                    + y % (panel_rows_/4));
-    }
+  void MapSinglePanel(int x, int y, int *matrix_x, int *matrix_y) const {
+    const bool is_top_stripe = (y % (panel_rows_/2)) < panel_rows_/4;
+    const int panel_quarter = panel_cols_/4;
+    const int quarter = x / panel_quarter;
+    const int offset = x % panel_quarter;
+    *matrix_x = ((2*quarter*panel_quarter)
+                 + (is_top_stripe
+                    ? panel_quarter - 1 - offset
+                    : panel_quarter + offset));
+    *matrix_y = ((y / (panel_rows_/2)) * (panel_rows_/4)
+                 + y % (panel_rows_/4));
+  }
 };
 
 class ZStripeMultiplexMapper : public MultiplexMapperBase {
 public:
-    ZStripeMultiplexMapper() : MultiplexMapperBase("ZStripe", 2) {}
+  ZStripeMultiplexMapper() : MultiplexMapperBase("ZStripe", 2) {}
 
-    void MapSinglePanel(int x, int y, int *logic_x, int *logic_y) const {
-        const int xoffset = 8 * (x / 8);
-        const int yoffset = (y % 8) / 4;
+  void MapSinglePanel(int x, int y, int *matrix_x, int *matrix_y) const {
+    const int xoffset = 8 * (x / 8);
+    const int yoffset = (y % 8) / 4;
 
-        *logic_x = x + 8 * yoffset + xoffset;
-        *logic_y = (y % 4) + 4 * (y / 8);
-    }
+    *matrix_x = x + 8 * yoffset + xoffset;
+    *matrix_y = (y % 4) + 4 * (y / 8);
+  }
 };
 
 /*
@@ -153,20 +153,20 @@ public:
  * made available in the --led-multiplexing commandline option.
  */
 static MuxMapperList *CreateMultiplexMapperList() {
-    MuxMapperList *result = new MuxMapperList();
+  MuxMapperList *result = new MuxMapperList();
 
-    // Here, register all multiplex mappers from above.
-    result->push_back(new StripeMultiplexMapper());
-    result->push_back(new CheckeredMultiplexMapper());
-    result->push_back(new SpiralMultiplexMapper());
-    result->push_back(new ZStripeMultiplexMapper());
+  // Here, register all multiplex mappers from above.
+  result->push_back(new StripeMultiplexMapper());
+  result->push_back(new CheckeredMultiplexMapper());
+  result->push_back(new SpiralMultiplexMapper());
+  result->push_back(new ZStripeMultiplexMapper());
 
-    return result;
+  return result;
 }
 
 const MuxMapperList &GetRegisteredMultiplexMappers() {
-    static const MuxMapperList *all_mappers = CreateMultiplexMapperList();
-    return *all_mappers;
+  static const MuxMapperList *all_mappers = CreateMultiplexMapperList();
+  return *all_mappers;
 }
 }  // namespace internal
 }  // namespace rgb_matrix

--- a/lib/pixel-mapper.cc
+++ b/lib/pixel-mapper.cc
@@ -27,156 +27,156 @@ namespace {
 
 class RotatePixelMapper : public PixelMapper {
 public:
-    RotatePixelMapper() : angle_(0) {}
+  RotatePixelMapper() : angle_(0) {}
 
-    virtual const char *GetName() const { return "Rotate"; }
+  virtual const char *GetName() const { return "Rotate"; }
 
-    virtual bool SetParameters(int chain, int parallel, const char *param) {
-        if (param == NULL || strlen(param) == 0) {
-            angle_ = 0;
-            return true;
-        }
-        char *errpos;
-        const int angle = strtol(param, &errpos, 10);
-        if (*errpos != '\0') {
-            fprintf(stderr, "Invalid rotate parameter '%s'\n", param);
-            return false;
-        }
-        if (angle % 90 != 0) {
-            fprintf(stderr, "Rotation needs to be multiple of 90 degrees\n");
-            return false;
-        }
-        angle_ = (angle + 360) % 360;
-        return true;
+  virtual bool SetParameters(int chain, int parallel, const char *param) {
+    if (param == NULL || strlen(param) == 0) {
+      angle_ = 0;
+      return true;
     }
-
-    virtual bool GetSizeMapping(int matrix_width, int matrix_height,
-                                int *visible_width, int *visible_height)
-        const {
-        if (angle_ % 180 == 0) {
-            *visible_width = matrix_width;
-            *visible_height = matrix_height;
-        } else {
-            *visible_width = matrix_height;
-            *visible_height = matrix_width;
-        }
-        return true;
+    char *errpos;
+    const int angle = strtol(param, &errpos, 10);
+    if (*errpos != '\0') {
+      fprintf(stderr, "Invalid rotate parameter '%s'\n", param);
+      return false;
     }
-
-    virtual void MapVisibleToMatrix(int matrix_width, int matrix_height,
-                                    int x, int y,
-                                    int *matrix_x, int *matrix_y) const {
-        switch (angle_) {
-        case 0:
-            *matrix_x = x;
-            *matrix_y = y;
-            break;
-        case 90:
-            *matrix_x = matrix_width - y - 1;
-            *matrix_y = x;
-            break;
-        case 180:
-            *matrix_x = matrix_width - x - 1;
-            *matrix_y = matrix_height - y - 1;
-            break;
-        case 270:
-            *matrix_x = y;
-            *matrix_y = matrix_height - x - 1;
-            break;
-        }
+    if (angle % 90 != 0) {
+      fprintf(stderr, "Rotation needs to be multiple of 90 degrees\n");
+      return false;
     }
+    angle_ = (angle + 360) % 360;
+    return true;
+  }
+
+  virtual bool GetSizeMapping(int matrix_width, int matrix_height,
+                              int *visible_width, int *visible_height)
+    const {
+    if (angle_ % 180 == 0) {
+      *visible_width = matrix_width;
+      *visible_height = matrix_height;
+    } else {
+      *visible_width = matrix_height;
+      *visible_height = matrix_width;
+    }
+    return true;
+  }
+
+  virtual void MapVisibleToMatrix(int matrix_width, int matrix_height,
+                                  int x, int y,
+                                  int *matrix_x, int *matrix_y) const {
+    switch (angle_) {
+    case 0:
+      *matrix_x = x;
+      *matrix_y = y;
+      break;
+    case 90:
+      *matrix_x = matrix_width - y - 1;
+      *matrix_y = x;
+      break;
+    case 180:
+      *matrix_x = matrix_width - x - 1;
+      *matrix_y = matrix_height - y - 1;
+      break;
+    case 270:
+      *matrix_x = y;
+      *matrix_y = matrix_height - x - 1;
+      break;
+    }
+  }
 
 private:
-    int angle_;
+  int angle_;
 };
 
 class UArrangementMapper : public PixelMapper {
 public:
-    UArrangementMapper() : parallel_(1) {}
+  UArrangementMapper() : parallel_(1) {}
 
-    virtual const char *GetName() const { return "U-mapper"; }
+  virtual const char *GetName() const { return "U-mapper"; }
 
-    virtual bool SetParameters(int chain, int parallel, const char *param) {
-        parallel_ = parallel;
-        return true;
+  virtual bool SetParameters(int chain, int parallel, const char *param) {
+    parallel_ = parallel;
+    return true;
+  }
+
+  virtual bool GetSizeMapping(int matrix_width, int matrix_height,
+                              int *visible_width, int *visible_height)
+    const {
+    *visible_width = (matrix_width / 64) * 32;   // Div at 32px boundary
+    *visible_height = 2 * matrix_height;
+    if (matrix_height % parallel_ != 0) {
+      fprintf(stderr, "%s For parallel=%d we would expect the height=%d "
+              "to be divisible by %d ??\n",
+              GetName(), parallel_, matrix_height, parallel_);
+      return false;
     }
+    return true;
+  }
 
-    virtual bool GetSizeMapping(int matrix_width, int matrix_height,
-                                int *visible_width, int *visible_height)
-        const {
-        *visible_width = (matrix_width / 64) * 32;   // Div at 32px boundary
-        *visible_height = 2 * matrix_height;
-        if (matrix_height % parallel_ != 0) {
-            fprintf(stderr, "%s For parallel=%d we would expect the height=%d "
-                    "to be divisible by %d ??\n",
-                    GetName(), parallel_, matrix_height, parallel_);
-            return false;
-        }
-        return true;
+  virtual void MapVisibleToMatrix(int matrix_width, int matrix_height,
+                                  int x, int y,
+                                  int *matrix_x, int *matrix_y) const {
+    const int panel_height = matrix_height / parallel_;
+    const int visible_width = (matrix_width / 64) * 32;
+    const int slab_height = 2 * panel_height;   // one folded u-shape
+    const int base_y = (y / slab_height) * panel_height;
+    y %= slab_height;
+    if (y < panel_height) {
+      x += matrix_width / 2;
+    } else {
+      x = visible_width - x - 1;
+      y = slab_height - y - 1;
     }
-
-    virtual void MapVisibleToMatrix(int matrix_width, int matrix_height,
-                                    int x, int y,
-                                    int *matrix_x, int *matrix_y) const {
-        const int panel_height = matrix_height / parallel_;
-        const int visible_width = (matrix_width / 64) * 32;
-        const int slab_height = 2 * panel_height;   // one folded u-shape
-        const int base_y = (y / slab_height) * panel_height;
-        y %= slab_height;
-        if (y < panel_height) {
-            x += matrix_width / 2;
-        } else {
-            x = visible_width - x - 1;
-            y = slab_height - y - 1;
-        }
-        *matrix_x = x;
-        *matrix_y = base_y + y;
-    }
+    *matrix_x = x;
+    *matrix_y = base_y + y;
+  }
 
 private:
-    int parallel_;
+  int parallel_;
 };
 
 typedef std::map<std::string, PixelMapper*> MapperByName;
 static void RegisterPixelMapperInternal(MapperByName *registry,
                                         PixelMapper *mapper) {
-    assert(mapper != NULL);
-    // TODO: tolower case ?
-    (*registry)[mapper->GetName()] = mapper;
+  assert(mapper != NULL);
+  // TODO: tolower case ?
+  (*registry)[mapper->GetName()] = mapper;
 }
 
 static MapperByName *CreateMapperMap() {
-    MapperByName *result = new MapperByName();
+  MapperByName *result = new MapperByName();
 
-    // Register all the default PixelMappers here.
-    RegisterPixelMapperInternal(result, new RotatePixelMapper());
-    RegisterPixelMapperInternal(result, new UArrangementMapper());
-    return result;
+  // Register all the default PixelMappers here.
+  RegisterPixelMapperInternal(result, new RotatePixelMapper());
+  RegisterPixelMapperInternal(result, new UArrangementMapper());
+  return result;
 }
 
 static MapperByName *GetMapperMap() {
-    static MapperByName *singleton_instance = CreateMapperMap();
-    return singleton_instance;
+  static MapperByName *singleton_instance = CreateMapperMap();
+  return singleton_instance;
 }
 }  // anonymous namespace
 
 // Public API.
 void RegisterPixelMapper(PixelMapper *mapper) {
-    RegisterPixelMapperInternal(GetMapperMap(), mapper);
+  RegisterPixelMapperInternal(GetMapperMap(), mapper);
 }
 
 const PixelMapper *FindPixelMapper(const char *name,
                                    int chain, int parallel,
                                    const char *parameter) {
-    MapperByName::const_iterator found = GetMapperMap()->find(name);
-    if (found == GetMapperMap()->end()) {
-        fprintf(stderr, "%s: no such mapper\n", name);
-        return NULL;
-    }
-    PixelMapper *mapper = found->second;
-    if (mapper == NULL) return NULL;  // should not happen.
-    if (parameter && !mapper->SetParameters(chain, parallel, parameter))
-        return NULL;   // Got parameter, but couldn't deal with it.
-    return mapper;
+  MapperByName::const_iterator found = GetMapperMap()->find(name);
+  if (found == GetMapperMap()->end()) {
+    fprintf(stderr, "%s: no such mapper\n", name);
+    return NULL;
+  }
+  PixelMapper *mapper = found->second;
+  if (mapper == NULL) return NULL;  // should not happen.
+  if (parameter && !mapper->SetParameters(chain, parallel, parameter))
+    return NULL;   // Got parameter, but couldn't deal with it.
+  return mapper;
 }
 }  // namespace rgb_matrix


### PR DESCRIPTION
o Indentation was 4 instead of 2 in the new *.cc files.
o visible -> matrix makes more sense for the naming in
  MultiplexMapperBase::MapSinglePanel() so use that.